### PR TITLE
Install libconfig-dev to avoid build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update && apt-get install -y libmicrohttpd-dev \
     libogg-dev \
     libini-config-dev \
     libcollection-dev \
+    libconfig-dev \
     pkg-config \
     gengetopt \
     libtool \


### PR DESCRIPTION
See https://github.com/atyenoria/janus-webrtc-gateway-docker/issues/20 for more details.