### PR TITLE
Update Janus to v 0.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -267,10 +267,10 @@ RUN cd / && git clone https://github.com/sctplab/usrsctp.git && cd /usrsctp && \
 
 
 
-# tag v0.7.4 https://github.com/meetecho/janus-gateway/commit/5ff6907fc9cc6c64d8dc3342969abebad74cc964
+# tag v0.7.6 https://github.com/meetecho/janus-gateway/commit/87525fbaffc36902593d94ef0f5cdc66fd05a66e
 RUN cd / && git clone https://github.com/meetecho/janus-gateway.git && cd /janus-gateway && \
     sh autogen.sh &&  \
-    git checkout origin/master && git reset --hard 5ff6907fc9cc6c64d8dc3342969abebad74cc964 && \ 
+    git checkout origin/master && git reset --hard 87525fbaffc36902593d94ef0f5cdc66fd05a66e && \
     PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure \
     --enable-post-processing \
     --enable-boringssl \
@@ -300,4 +300,4 @@ CMD nginx && janus
 #     bash autogen.sh && \
 #     ./configure && \
 #     make && \
-#     make install 
+#     make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:stretch
 
 RUN sed -i 's/archive.ubuntu.com/mirror.aarnet.edu.au\/pub\/ubuntu\/archive/g' /etc/apt/sources.list
 
@@ -46,10 +46,11 @@ RUN YASM="1.3.0" && cd ~/ffmpeg_sources && \
     make install && \
     make distclean
 
-RUN VPX="1.5.0" && cd ~/ffmpeg_sources && \
-    wget http://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-1.5.0.tar.bz2 && \
-    tar xjvf libvpx-$VPX.tar.bz2 && \
-    cd libvpx-$VPX && \
+RUN VPX="v1.8.1" && cd ~/ffmpeg_sources && \
+    wget https://chromium.googlesource.com/webm/libvpx/+archive/$VPX.tar.gz && \
+    tar xzvf $VPX.tar.gz && \
+    pwd \
+    cd $VPX && \
     PATH="$HOME/bin:$PATH" ./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests && \
     PATH="$HOME/bin:$PATH" make && \
     make install && \
@@ -84,7 +85,7 @@ RUN X264="20181001-2245-stable" && cd ~/ffmpeg_sources && \
     make install && \
     make distclean
 
-RUN FDK_AAC="0.1.4" && cd ~/ffmpeg_sources && \
+RUN FDK_AAC="2.0.1" && cd ~/ffmpeg_sources && \
     wget -O fdk-aac.tar.gz https://github.com/mstorsjo/fdk-aac/archive/v$FDK_AAC.tar.gz && \
     tar xzvf fdk-aac.tar.gz && \
     cd fdk-aac-$FDK_AAC && \
@@ -146,7 +147,7 @@ RUN ZLIB="zlib-1.2.11" && vNGRTMP="v1.1.11" && PCRE="8.41" && nginx_build=/root/
     tar zxf $vNGRTMP.tar.gz && mv nginx-rtmp-module-* nginx-rtmp-module
 
 
-RUN OPENRESTY="1.13.6.1" && ZLIB="zlib-1.2.11" && PCRE="pcre-8.41" &&  openresty_build=/root/openresty && mkdir $openresty_build && \
+RUN OPENRESTY="1.13.6.2" && ZLIB="zlib-1.2.11" && PCRE="pcre-8.41" &&  openresty_build=/root/openresty && mkdir $openresty_build && \
     wget https://openresty.org/download/openresty-$OPENRESTY.tar.gz && \
     tar zxf openresty-$OPENRESTY.tar.gz && \
     cd openresty-$OPENRESTY && \
@@ -227,10 +228,9 @@ RUN SRTP="2.2.0" && apt-get remove -y libsrtp0-dev && wget https://github.com/ci
 
 # 8 March, 2019 1 commit 67807a17ce983a860804d7732aaf7d2fb56150ba
 RUN apt-get remove -y libnice-dev libnice10 && \
-    echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
-    apt-get -o Acquire::Check-Valid-Until=false update && \
-    apt-get install -y gtk-doc-tools libgnutls28-dev -t jessie-backports  && \
-    apt-get install -y libglib2.0-0 -t jessie-backports && \
+    echo "deb http://deb.debian.org/debian  stretch-backports main" >> /etc/apt/sources.list && \
+    apt-get  update && \
+    apt-get install -y gtk-doc-tools libgnutls28-dev -t stretch-backports  && \
     git clone https://gitlab.freedesktop.org/libnice/libnice.git && \
     cd libnice && \
     git checkout 67807a17ce983a860804d7732aaf7d2fb56150ba && \

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ https://www.useloom.com/share/325799006d6f4b64a6ce0662ca3f1d57
 # Dockerfile Characteristics
 - libwebsocket v3.1.0, build with LWS_MAX_SMP=1, ipv6=true for single thread processing
 - libsrtp v2.2.0
-- ffmpeg 4.0.2 with vpx, libx264, alsa(for headless chrome screen caputreing)
+- ffmpeg 4.2.1 with vpx, libx264, alsa(for headless chrome screen caputreing)
 - coturn v4.5.0.8 in order to test turn, use iceTransportPolicy=relay https://www.w3.org/TR/webrtc/#rtcicetransportpolicy-enum 
-- openresty 1.13.6.1
+- openresty 1.13.6.2
 - boringssl stable https://boringssl.googlesource.com/boringssl/+/chromium-stable 
 - libnice v0.1.14 https://github.com/libnice/libnice/releases/tag/0.1.14 
 - golang 1.7.5 for building boringssl
-- janus v0.7.4, enable all janus plugins(like videoroom, streaming, audiobridge...etc)
+- janus v0.7.6, enable all janus plugins(like videoroom, streaming, audiobridge...etc)
 - libnice from the latest gitlab https://gitlab.freedesktop.org/libnice/libnice  (removing global lock for improving janus gateway)
 - [optional] GDB, Address Sanitizer(optional, see Dockerfile) for getting more info when crashing
 - nginx-rtmp-module and ffmpeg compile for MCU functionalilty experiment. For example, WEBRTC-HLS, DASH, RTMP...etc


### PR DESCRIPTION
Look like debian jessie is too old.  Some issue is occurred after update Janus version to 0.7.6.
https://github.com/meetecho/janus-gateway/issues/1887

Due to this, I've tried to update the docker image to fit 0.7.6 properly.
Some package versions should be updated to resolve incompatibility: 

libvpx: 
Update to latest stable version and update URL as libvpx use another location for storing releases: 
https://chromium.googlesource.com/webm/libvpx

FDK_AAC: 
build failed with version "0.1.4",.  after updated it to 2.0.1" error is disrepair.

openresty:
https://github.com/openresty/encrypted-session-nginx-module/issues/12

libglib2.0:
```
    apt-get install -y libglib2.0-0 -t jessie-backports && \
```
libglib2  is already installed and on the latest stable version.